### PR TITLE
Allow to send coverage in development

### DIFF
--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -60,8 +60,8 @@ module.exports = {
   },
 
   contentFor(type) {
-    let isRightRype = type === 'test-body-footer' || type === 'code-coverage-footer';
-    if (isRightRype && this._isCoverageEnabled()) {
+    let isRightType = type === 'test-body-footer' || type === 'code-coverage-footer';
+    if (isRightType && this._isCoverageEnabled()) {
       var template = fs
         .readFileSync(path.join(__dirname, 'lib', 'templates', 'test-body-footer.html'))
         .toString();

--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -60,14 +60,17 @@ module.exports = {
   },
 
   contentFor(type) {
-    if (type === 'test-body-footer' && this._isCoverageEnabled()) {
+    let isRightRype = type === 'test-body-footer' || type === 'code-coverage-footer';
+    if (isRightRype && this._isCoverageEnabled()) {
       var template = fs
         .readFileSync(path.join(__dirname, 'lib', 'templates', 'test-body-footer.html'))
         .toString();
-      return template.replace(
+      template = template.replace(
         '{%ENTRIES%}',
         JSON.stringify(Object.keys(this.fileLookup).map(file => file.replace(EXT_RE, '')))
       );
+      template = template.replace('{%EMBER_ENV%}', process.env.EMBER_ENV || 'development');
+      return template;
     }
 
     return undefined;

--- a/packages/ember-cli-code-coverage/lib/templates/test-body-footer.html
+++ b/packages/ember-cli-code-coverage/lib/templates/test-body-footer.html
@@ -36,12 +36,12 @@
     after(function(done) {
       sendCoverage(done);
     });
-  } else {
+  } else if ('{%EMBER_ENV%}' === 'test') {
     console.warn('No testing framework found for ember-cli-code-coverage to integrate with.');
   }
 
   function handleCoverageResponse(xhr, callback) {
-    var data = xhr.response;
+    var data = typeof xhr.response === 'string' ? JSON.parse(xhr.response) : xhr.response;
 
     if (!data) {
       return;

--- a/packages/ember-cli-code-coverage/package.json
+++ b/packages/ember-cli-code-coverage/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ember-cli-code-coverage",
-  "version": "1.0.2",
+  "name": "@simplepractice/ember-cli-code-coverage",
+  "version": "1.0.3-beta.0",
   "description": "Code coverage for ember projects using Istanbul",
   "keywords": [
     "ember-addon"

--- a/test-packages/index-test.js
+++ b/test-packages/index-test.js
@@ -53,8 +53,9 @@ describe('index.js', function () {
         expect(Index.contentFor('test-head')).toEqual(undefined);
       });
 
-      it('returns template for test-body-footer', function () {
+      it('returns template for test-body-footer or code-coverage-footer', function () {
         expect(Index.contentFor('test-body-footer')).toMatch(/sendCoverage/);
+        expect(Index.contentFor('code-coverage-footer')).toMatch(/sendCoverage/);
       });
 
       it('includes the project name in the template for test-body-footer', function () {
@@ -478,7 +479,7 @@ describe('index.js', function () {
             'my-app/services/my-service.js',
             'my-app/utils/my-covered-util.js',
             'my-app/utils/my-uncovered-util.js',
-            
+
           ]);
           expect(Index.fileLookup).toEqual({
             "my-app/services/my-service.js": "lib/my-in-repo-addon/app/services/my-service.js",


### PR DESCRIPTION
These changes aim to add support for coverage measurement when running in dev mode. The use case I had for this is making integration specs (which are using Capybara) collect and report frontend app coverage.

The summary of the PR is:
- Add an alias for `content-for` (called `code-coverage-footer`) so it can be used in non-test index.html without additional content that comes with ember-cli
- Change `sendCoverage` to handle JSON response better and make it not emit integration warning for non-test Ember env
