### PR TITLE
Handle relative paths when fixing keys

### DIFF
--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -70,17 +70,15 @@ function adjustCoverageKey(
 ) {
   let relativePath = path.relative(root, filepath);
 
-  // This lives in a directory outside of the current one, likely a monorepo.
-  // In this case we can assume that the original path is correct.
-  if (relativePath.startsWith('..')) {
-    return filepath;
-  }
-
   let embroiderTmpPathRegex = /embroider\/.{6}/gm;
 
   // we can determine if file is coming from embroider based on how the path looks
   if (embroiderTmpPathRegex.test(filepath)) {
     relativePath = normalizeRelativePath(root, filepath);
+  } else if (relativePath.startsWith('..')) {
+    // This lives in a directory outside of the current one, likely a monorepo.
+    // In this case we can assume that the original path is correct.
+    return filepath;
   }
 
   let namespace = relativePath.split(path.sep)[0];

--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -69,6 +69,13 @@ function adjustCoverageKey(
   modifyAssetLocation
 ) {
   let relativePath = path.relative(root, filepath);
+
+  // This lives in a directory outside of the current one, likely a monorepo.
+  // In this case we can assume that the original path is correct.
+  if (relativePath.startsWith('..')) {
+    return filepath;
+  }
+
   let embroiderTmpPathRegex = /embroider\/.{6}/gm;
 
   // we can determine if file is coming from embroider based on how the path looks


### PR DESCRIPTION
We have a mono repo with v2-style in-repo addons and tests. For instance, we have `ROOT/addons/internal` and `ROOT/tests/internal`. The path relative to our tests end up looking like `../../addons/internal`. Without the new conditional, we'd end up hitting the fallback case which tries to make everything relative to `tests/internal/app` this would end up getting translated into `ROOT/tests/addons/internal` which is _not_ the correct path. I believe it should always be correct to pass relative paths through as-is, which is what I've done here. This solves the problem for our uses.