### PR TITLE
Add Config per Reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,13 @@ Configuration is optional. It should be put in a file at `config/coverage.js` (`
 
 - `coverageEnvVar`: Defaults to `COVERAGE`. This is the environment variable that when set will cause coverage metrics to be generated.
 
-- `reporters`: Defaults to `['lcov', 'html']`. The `json-summary` reporter will be added to anything set here, it is required. This can be any [reporters supported by Istanbul](https://github.com/gotwarlost/istanbul/tree/master/lib/report).
+- `reporters`: Defaults to `['lcov', 'html']`. The `json-summary` reporter will
+  be added to anything set here, it is required. This can be any [reporters
+  supported by
+  Istanbul](https://github.com/gotwarlost/istanbul/tree/master/lib/report).
+  Reporters can be configured with array-style syntax, for example, here are
+  options to `lcov` with a different `projectRoot`: `[['lcov', { projectRoot:
+  '/packages/addon' }], 'html']`
 
 - `excludes`: Defaults to `['*/mirage/**/*']`. An array of globs to exclude from instrumentation. Useful to exclude files from coverage statistics.
 

--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -3,12 +3,13 @@
 const bodyParser = require('body-parser').json({ limit: '500mb' });
 const libCoverage = require('istanbul-lib-coverage');
 const libReport = require('istanbul-lib-report');
-const reports = require('istanbul-reports');
+
 const getConfig = require('./config');
 const path = require('path');
 const crypto = require('crypto');
 const fs = require('fs-extra');
 const libSourceMaps = require('istanbul-lib-source-maps');
+const { createReport } = require('./reports');
 
 const sourceMapStore = libSourceMaps.createSourceMapStore();
 
@@ -219,7 +220,7 @@ function reportCoverage(map, root, configPath) {
   });
 
   reporters.forEach((reporter) => {
-    let report = reports.create(reporter, {});
+    let report = createReport(reporter);
 
     // call execute to synchronously create and write the report to disk
     report.execute(context);

--- a/packages/ember-cli-code-coverage/lib/coverage-merge.js
+++ b/packages/ember-cli-code-coverage/lib/coverage-merge.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const getConfig = require('./config');
 const dir = require('node-dir');
+const { createReport } = require('./reports');
 
 /**
  * Merge together coverage files created when running in multiple threads,
@@ -15,7 +16,6 @@ module.exports = {
   run() {
     const libCoverage = require('istanbul-lib-coverage');
     const libReport = require('istanbul-lib-report');
-    const reports = require('istanbul-reports');
 
     let config = this._getConfig();
 
@@ -56,7 +56,7 @@ module.exports = {
           });
 
           reporters.forEach((reporter) => {
-            let report = reports.create(reporter, {});
+            let report = createReport(reporter);
 
             // call execute to synchronously create and write the report to disk
             report.execute(context);

--- a/packages/ember-cli-code-coverage/lib/reports.js
+++ b/packages/ember-cli-code-coverage/lib/reports.js
@@ -1,0 +1,11 @@
+const reports = require('istanbul-reports');
+
+function createReport(reporter) {
+  return Array.isArray(reporter)
+    ? reports.create(reporter[0], reporter[1])
+    : reports.create(reporter, {});
+}
+
+module.exports = {
+  createReport,
+};

--- a/test-packages/reports-test.mjs
+++ b/test-packages/reports-test.mjs
@@ -1,0 +1,24 @@
+'use strict';
+
+import { createReport } from '../packages/ember-cli-code-coverage/lib/reports';
+import { expect, describe, it } from 'vitest';
+
+describe('reports', () => {
+  it('createReport with simple reporter', async () => {
+    const report = createReport('lcov');
+
+    expect(Object.keys(report)).toContain('lcov');
+  });
+
+  it('createReport with options', async () => {
+    const report = createReport([
+      'lcov',
+      {
+        projectRoot: 'some/where/else',
+      },
+    ]);
+
+    expect(Object.keys(report)).toContain('lcov');
+    expect(report.lcov.projectRoot).toBe('some/where/else');
+  });
+});

--- a/test-packages/utils.mjs
+++ b/test-packages/utils.mjs
@@ -8,7 +8,7 @@ import { execa } from 'execa';
 export default async function setupTestDir(APP_DIR, env, deps) {
   const project = Project.fromDir(`test-packages/${APP_DIR}`, { linkDevDeps: true });
 
-  for (const [key,value] of Object.entries(deps)) {
+  for (const [key, value] of Object.entries(deps)) {
     project.addDevDependency(key, value);
   }
 
@@ -68,9 +68,8 @@ export async function assertCoverageExists(buildPath) {
   expect(summary).toMatchSnapshot();
 }
 
-
 export async function assertFileExists(path) {
-  if (!await exists(path)) {
+  if (!(await exists(path))) {
     throw new Error(`File ${path} does not exist`);
   }
 }
@@ -82,5 +81,5 @@ export async function assertDirDoesNotExists(dir) {
 }
 
 export async function assertFileIsNotEmpty(path) {
-  return  (await readFile(path, 'utf8').length) > 0;
+  return (await readFile(path, 'utf8').length) > 0;
 }


### PR DESCRIPTION
I'm using codeclimate for my OSS projects. And for that to work, the code-coverage must be relative to repo-root, instead of project-root. This was easy done with the `vitest` project in there as it allowed to configure reports: https://vitest.dev/guide/reporters.html (it's also the same syntax that eslint uses to configure your rules).

In `ember-cli-code-coverage`, the config is always `{}` or "no config allowed". Now this PR adds support for the same config, that `vitest` allows.

I'm already using this with a patch on my OSS projects, here is one such [PR pointed to the config](https://github.com/hokulea/aria-voyager/pull/8/files#diff-1eac964ac8ee654baaf6c1c509383e0400a49292fda5a7b13e59249939159014).

It works, I can see my coverage on codeclimate and this PR brings back this support to everybody :)